### PR TITLE
Fix commit counting, do full checkout

### DIFF
--- a/.github/workflows/publish-jar.yml
+++ b/.github/workflows/publish-jar.yml
@@ -11,6 +11,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
       - uses: actions/setup-java@v3
         with:
           java-version: '11'


### PR DESCRIPTION
Without full commit checkout, the count of commits is always '1'. This does not work well when we use the commit count for build number. By doing a full checkout, we get teh full history and an accurate count.